### PR TITLE
fix: Typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ we can use BuildKit with the `TARGETPLATFORM` argument to get a more consistent 
 
 `TARGETPLATFORM` is actually the combo of `TARGETOS`/`TARGETARCH`/`TARGETVARIANT` so in some cases you could use
 those to help the situation, but as you can see below, the arm/v6 vs arm/v7 vs arm/v8 output can make all this
-tricky. `TARGETARCH` is too general, and `TARGEVARIANT` may be blank (in the case of `arm64`).
+tricky. `TARGETARCH` is too general, and `TARGETVARIANT` may be blank (in the case of `arm64`).
 
 So when I use `docker buildx build --platform`, what do I see inside the BuildKit environment?
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ we can use BuildKit with the `TARGETPLATFORM` argument to get a more consistent 
 
 `TARGETPLATFORM` is actually the combo of `TARGETOS`/`TARGETARCH`/`TARGETVARIANT` so in some cases you could use
 those to help the situation, but as you can see below, the arm/v6 vs arm/v7 vs arm/v8 output can make all this
-tricky. `TARGETARCH` is to general, and `ARGETVARIANT` may be blank (in the case of `arm64`).
+tricky. `TARGETARCH` is too general, and `TARGEVARIANT` may be blank (in the case of `arm64`).
 
 So when I use `docker buildx build --platform`, what do I see inside the BuildKit environment?
 
@@ -65,7 +65,7 @@ RUN printf "I'm building for TARGETPLATFORM=${TARGETPLATFORM}" \
     && printf ", TARGETARCH=${TARGETARCH}" \
     && printf ", TARGETVARIANT=${TARGETVARIANT} \n" \
     && printf "With uname -s : " && uname -s \
-    && printf "and  uname -m : " && uname -mm
+    && printf "and  uname -m : " && uname -m
 ```
 
 Here are the results when using the command `docker buildx build --progress=plain --platform=<VALUE> .`:


### PR DESCRIPTION
Thanks for putting this repo together. It's been really handy for a multi platform Dart thing I'm working on.

I spotted a few typos in the README as I was going through it.